### PR TITLE
Fix No ACL input available - Issue #7

### DIFF
--- a/Invoke-ACLPwn.ps1
+++ b/Invoke-ACLPwn.ps1
@@ -1410,10 +1410,10 @@ function Get-SharpHoundACL ([string]$sharpHoundLocation, $isNewVersion) {
 
     if ($isNewVersion){
         $fileName = "{0}.zip" -f [datetime]::Now.ToFileTime()
-        $arg = "$($global:ldapConnInfo.domain) -c acl --ZipFileName $($fileName) --NoSaveCache --OutputDirectory $($env:tmp)"
+        $arg = "$($global:ldapConnInfo.domain) -c acl --ZipFileName $($fileName) --OutputDirectory $($env:tmp)"
     } else {
         $fileName = "{0}" -f [datetime]::Now.ToFileTime()
-        $arg = "-d $($global:ldapConnInfo.domain) -c acl --CSVPrefix $($fileName) --NoSaveCache --OutputDirectory $($env:tmp)"
+        $arg = "-d $($global:ldapConnInfo.domain) -c acl --CSVPrefix $($fileName) --OutputDirectory $($env:tmp)"
     }
 
     Invoke-Cmd -cmd $sharpHoundLocation -argV $arg

--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ a "chain" that leads to domain administrative privilges in the target domain.
 No installation is needed, however, in order to run Invoke-ACLpwn, a few
 depedencies must be met:
 * `.NET 3.5` or later
-* `sharphound.exe`
+* `sharphound.exe 3.0.0.0`
+* `Mimikatz.exe 2.2.0` 
+
+* Tested on: Windows 10.0 Build 14393
 * If you want to run DCsync, you need `mimikatz.exe` as well.
 
 ## Usage


### PR DESCRIPTION
Changed save location to current user's temp folder.
Fixed Issue #7: Which would result in the "No ACL Input" error.
Added minimum version numbers of both mimikatz and sharphound. (Old versions could cause errors) 